### PR TITLE
Use mails_viewer in development env

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'devise'
 gem 'settingslogic'
 
 group :development do
+  gem 'mails_viewer'
   gem 'quiet_assets'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,8 +119,6 @@ GEM
     jquery-rails (2.1.4)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
-    json (1.7.5)
-    json (1.7.5-java)
     json (1.7.6)
     json (1.7.6-java)
     kramdown (0.14.1)
@@ -134,6 +132,8 @@ GEM
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
+    mails_viewer (0.0.3)
+      rails (>= 3.1.0)
     method_source (0.8.1)
     mime-types (1.19)
     multi_json (1.5.0)
@@ -283,6 +283,7 @@ DEPENDENCIES
   jquery-rails
   kramdown
   libv8 (= 3.11.8.3)
+  mails_viewer
   mysql2
   pg
   pry-rails

--- a/config/initializers/setup_mail.rb
+++ b/config/initializers/setup_mail.rb
@@ -1,5 +1,9 @@
 NineteenWu::Application.configure do
   config.action_mailer.delivery_method = Settings.email.delivery_method.to_sym
+  if Rails.env.development? || Rails.env.test?
+    config.action_mailer.delivery_method = Rails.env.test? ? :test : :file
+  end
+
   delivery_settings_key = "#{Settings.email.delivery_method}_settings"
   if delivery_settings = Settings.email[delivery_settings_key]
     config.action_mailer.send "#{delivery_settings_key}=", delivery_settings.symbolize_keys

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,4 +68,8 @@ NineteenWu::Application.routes.draw do
   # This is a legacy wild controller route that's not recommended for RESTful applications.
   # Note: This route will make all actions in every controller accessible via GET requests.
   # match ':controller(/:action(/:id))(.:format)'
+
+  if defined?(MailsViewer)
+    mount MailsViewer::Engine => '/delivered_mails'
+  end
 end

--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -27,7 +27,7 @@ development:
     <<: *email
     host: 'localhost:3000'
     from: 'development@19wu.com'
-    delivery_method: :smtp
+    delivery_method: :file
 
 test:
   <<: *defaults


### PR DESCRIPTION
Ease email preview and accounts activation

开发环境可以直接通过 /delivered_mails 打开 HTML/TEXT 预览
