### PR TITLE
Heroku settings

### DIFF
--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -4,4 +4,9 @@
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
-NineteenWu::Application.config.secret_token = 'c51d3acad27f10e29da85fa41c5d6b35ad65e187776fbc721a52c13365de0c07bd4d61a867a21dc0cb11277061754e8550146d2a79cedf07b4ce489e820a6d1c'
+
+if Settings[:secret_token] && Settings[:secret_token].size >= 30
+  NineteenWu::Application.config.secret_token = Settings[:secret_token]
+else
+  NineteenWu::Application.config.secret_token = 'c51d3acad27f10e29da85fa41c5d6b35ad65e187776fbc721a52c13365de0c07bd4d61a867a21dc0cb11277061754e8550146d2a79cedf07b4ce489e820a6d1c'
+end

--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -64,3 +64,10 @@ test:
 
 production:
   <<: *defaults
+
+  # Generate a secret setting for production and do not share it in public repo
+  #
+  # The token must be at least 30 characters, otherwise the default on in
+  # config/initializers/secret_token.rb is used
+  #
+  # secret_token: ''


### PR DESCRIPTION
-   添加 email 相关配置的说明
-   可以通过 settings.yml 在 production 环境中设置 secret_token
