### PR TITLE
活动起止时间输入框宽度要适应小屏幕

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -35,3 +35,5 @@
 
 @import "modules/sidebar";
 @import "modules/event";
+
+@import "modules/form_responsive";

--- a/app/assets/stylesheets/modules/_form.css.scss
+++ b/app/assets/stylesheets/modules/_form.css.scss
@@ -25,24 +25,20 @@ form {
 }
 
 .compound-datetime {
-  select {
-    width: auto;
+  .datepicker {
+    width: 98px;
   }
-  > .date {
-    margin-bottom: $baseLineHeight / 4;
-    margin-right: 5px;
-    > .add-on {
-      margin-top: 1px;
-    }
+  .add-on {
+    margin-top: 1px;
   }
-  > .time {
-    > .time-min {
-      margin-right: 5px;
-    }
-    > select {
-      margin-bottom: $baseLineHeight / 8;
-    }
-  }
+}
+.time-hour, .time-min {
+  width: 45%;
+}
+.time-colon {
+  display: inline-block;
+  width: 10%;
+  text-align: center;
 }
 
 .uploadable-input {

--- a/app/assets/stylesheets/modules/_form_responsive.css.scss
+++ b/app/assets/stylesheets/modules/_form_responsive.css.scss
@@ -1,0 +1,24 @@
+// http://www.studiopress.com/responsive/
+// http://mattkersley.com/responsive/
+
+// datepicker input append a fixed-width add-on, so we can't use percent width
+/* Responsive: Tablet to desktop */
+@media (min-width: 768px) and (max-width: 979px) {
+  .compound-datetime .datepicker {
+    width: 73px;
+  }
+}
+
+/* Responsive: Landscape phone to desktop/tablet */
+@media (max-width: 767px) {
+  .compound-datetime .datepicker {
+    width: 289px;
+  }
+}
+
+/* Landscape phones and down */
+@media (max-width: 480px) {
+  .compound-datetime .datepicker {
+    width: 359px;
+  }
+}

--- a/app/inputs/compound_datetime_input.rb
+++ b/app/inputs/compound_datetime_input.rb
@@ -6,20 +6,20 @@ class CompoundDatetimeInput < SimpleForm::Inputs::Base
   def input
     datetime = @builder.object.send(attribute_name) || CompoundDatetime.new
     @builder.fields_for(attribute_name, datetime) do |f|
-      template.content_tag(:div, :class => 'compound-datetime row-fluid') do
+      template.content_tag(:div, :class => 'compound-datetime row') do # http://git.io/ArqfyA
         result = ''
-        result += template.content_tag(:span, :class => 'input-append date span5') do
-          f.text_field(:date, :class => 'span10 datepicker') +
+        result += template.content_tag(:div, :class => 'span2 date input-append pull-left') do
+          f.text_field(:date, :class => 'datepicker') +
             template.content_tag(:span, :class => 'add-on') do
             template.content_tag(:i, '', :class => 'icon-calendar datepicker-trigger')
           end
         end
-        result += template.content_tag(:span, :class => 'time span6') do
+        result += template.content_tag(:div, :class => 'span2') do
           f.select(:hour, HOUR_COLLECTION, {:include_blank => true}, :class => 'time-hour') +
-            template.content_tag(:span, ' : ', :class => 'muted') +
-            f.select(:min, MIN_COLLECTION, {:include_blank => true}, :class => 'time-min') +
-            f.select(:meridian, MERIDIAN_COLLECTION.call, {:include_blank => true}, :class => 'time-meridian')
+            template.content_tag(:span, ' : ', :class => 'time-colon muted') +
+            f.select(:min, MIN_COLLECTION, {:include_blank => true}, :class => 'time-min')
         end
+        result += f.select(:meridian, MERIDIAN_COLLECTION.call, {:include_blank => true}, :class => 'time-meridian span1')
 
         result.html_safe
       end

--- a/app/views/events/edit.html.slim
+++ b/app/views/events/edit.html.slim
@@ -12,8 +12,8 @@
 
           .form-inputs
             = f.input :title, :input_html => { :class => 'span5' }
-            = f.input :compound_start_time, :as => :compound_datetime
-            = f.input :compound_end_time, :as => :compound_datetime
+            = f.input :compound_start_time, :as => :compound_datetime, :controls_wrapper_html => { :class => 'controls-row' }
+            = f.input :compound_end_time, :as => :compound_datetime, :controls_wrapper_html => { :class => 'controls-row' }
             = f.input :location, :input_html => { :class => 'span5' }
             = f.input :location_guide, :input_html => { :rows => 6, :class => 'span5' }, :as => 'uploadable'
             = f.input :content, :input_html => { :rows => 12, :class => 'span5' }, :as => 'uploadable'

--- a/app/views/events/new.html.slim
+++ b/app/views/events/new.html.slim
@@ -10,8 +10,8 @@
 
           .form-inputs
             = f.input :title, :input_html => { :class => 'span5' }
-            = f.input :compound_start_time, :as => :compound_datetime
-            = f.input :compound_end_time, :as => :compound_datetime
+            = f.input :compound_start_time, :as => :compound_datetime, :controls_wrapper_html => { :class => 'controls-row' }
+            = f.input :compound_end_time, :as => :compound_datetime, :controls_wrapper_html => { :class => 'controls-row' }
             = f.input :location, :input_html => { :class => 'span5' }
             = f.input :location_guide, :input_html => { :rows => 6, :class => 'span5' }, :as => 'uploadable'
             = f.input :content, :input_html => { :rows => 12, :class => 'span5' }, :as => 'uploadable'

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -4,7 +4,7 @@ SimpleForm.setup do |config|
     b.use :html5
     b.use :placeholder
     b.use :label
-    b.wrapper :tag => 'div', :class => 'controls' do |ba|
+    b.wrapper :controls_wrapper, :tag => 'div', :class => 'controls' do |ba|
       ba.use :input
       ba.use :error, :wrap_with => { :tag => 'span', :class => 'help-inline' }
       ba.use :hint,  :wrap_with => { :tag => 'p', :class => 'help-block' }


### PR DESCRIPTION
768px 宽度及以上
![event-new-compound-datetime-responsive-768](https://f.cloud.github.com/assets/15178/82160/11002480-638f-11e2-9812-5dd9cd584af9.png)

480px 宽度
![event-new-compound-datetime-responsive-480](https://f.cloud.github.com/assets/15178/82162/17a212b2-638f-11e2-814b-6ab653affd96.png)

由于输入框内容较多，暂时不支持 480px 以下宽度。
#188
