### PR TITLE
调整首页样式.

### DIFF
--- a/app/assets/stylesheets/_0.variables.css.scss
+++ b/app/assets/stylesheets/_0.variables.css.scss
@@ -1,6 +1,6 @@
 /* Site settings */
 
-$grayBackground: #EFEDE8;
+$grayBackground: hsl(0, 0%, 97%);
 $borderColor: hsl(0, 0, 88);
 
 /* Bootstrap overrides */

--- a/app/assets/stylesheets/modules/_form.css.scss
+++ b/app/assets/stylesheets/modules/_form.css.scss
@@ -16,8 +16,14 @@ form {
     .btn {
       @extend .btn-block;
     }
+    .input-large {
+      min-height: $baseLineHeight * 2;
+      height: $baseLineHeight * 2;
+    }
+    .btn-large {
+      padding: 9px 19px; // http://git.io/D9i_5g
+    }
   }
-
 }
 
 .form-actions > .btn {

--- a/app/views/home/page.html.slim
+++ b/app/views/home/page.html.slim
@@ -2,19 +2,19 @@
 
   .jumbotron
     .container
-      .row-fluid
-        .span5
+      .row
+        .span7
           .slogan
             h1 = t('slogan.title')
             p = t('slogan.description')
-        .span5.offset2
+        .span4.offset1
           = simple_form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => { :class => 'form-full-width'}) do |f|
-            = f.input :login, :label => false, :placeholder => resource.class.human_attribute_name(:login)
-            = f.input :email, :label => false, :placeholder => resource.class.human_attribute_name(:email)
-            = f.input :password, :label => false, :placeholder => resource.class.human_attribute_name(:password)
-            = f.submit t('labels.sign_up_to_launch_event'), :class => 'btn btn-success'
+            = f.input :login, :label => false, :placeholder => resource.class.human_attribute_name(:login), :input_html => { :class => 'input-large'}
+            = f.input :email, :label => false, :placeholder => resource.class.human_attribute_name(:email), :input_html => { :class => 'input-large'}
+            = f.input :password, :label => false, :placeholder => resource.class.human_attribute_name(:password), :input_html => { :class => 'input-large'}
+            = f.submit t('labels.sign_up_to_launch_event'), :class => 'btn btn-success btn-large'
 
-.row-fluid
+.row
   .span3
     h3 = t('highlights.free.title')
     p = t('highlights.free.description')

--- a/config/locales/devise.zh-CN.yml
+++ b/config/locales/devise.zh-CN.yml
@@ -23,7 +23,7 @@ zh-CN:
       inactive: '您还没有激活帐户.'
     sessions:
       signed_in: '登录成功.'
-      signed_out: '退出成功.'
+      signed_out: '' # 首页不要显示退出成功提示
     passwords:
       send_instructions: '稍后你将收到帐号激活的电子邮件'
       updated: '您的密码已修改成功，您现在已登录.'

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -24,7 +24,7 @@ zh-CN:
 
   slogan:
     title: "卖活动票的小屋"
-    description: "由开源社区研发的活动票务平台，在这个小屋子发动活动、卖票都是免费的。"
+    description: "由开源社区研发的活动票务平台，在这个小屋子发起活动、卖票都是免费的。"
 
   highlights:
     free:
@@ -47,8 +47,8 @@ zh-CN:
   labels:
     sign_in: "登录"
     sign_up: "注册"
-    sign_up_to_launch_event: "注册，发动活动"
-    launch_event: "发动活动"
+    sign_up_to_launch_event: "注册，发起活动"
+    launch_event: "发起活动"
     show_event: "查看活动"
     cancel: "取消"
     join_event_button: "我要参加"


### PR DESCRIPTION
1. 右边的注册表单宽度缩小、输入框高度加大至 40px
2. 背景色灰色加亮，以提高对比度

---
### 修改前

![homepage-layout-0](https://f.cloud.github.com/assets/15178/88849/b1a2ff4a-6509-11e2-9193-6f0802d9e451.png)

---
### 修改后

![homepage-layout-1](https://f.cloud.github.com/assets/15178/88850/b618c884-6509-11e2-8fed-c5ddb7ef8dfe.png)
