### PR TITLE
使用 zeus 来加速 rails 环境启动

### DIFF
--- a/custom_plan.rb
+++ b/custom_plan.rb
@@ -1,0 +1,12 @@
+# touch config/boot.rb to restart zeus
+require 'zeus/rails'
+
+class CustomPlan < Zeus::Rails
+
+  # def my_custom_command
+  #  # see https://github.com/burke/zeus/blob/master/docs/ruby/modifying.md
+  # end
+
+end
+
+Zeus.plan = CustomPlan.new

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,8 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
-ENV["RAILS_ENV"] ||= 'test'
+ENV["RAILS_ENV"] = 'test'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
-require 'rspec/autorun'
+#require 'rspec/autorun' # http://j.mp/WLeAs3
 require 'capybara/email/rspec'
 
 class Capybara::Email::Driver

--- a/zeus.json
+++ b/zeus.json
@@ -1,0 +1,22 @@
+{
+  "command": "ruby -rubygems -r./custom_plan -eZeus.go",
+
+  "plan": {
+    "boot": {
+      "default_bundle": {
+        "development_environment": {
+          "prerake": {"rake": []},
+          "runner": ["r"],
+          "console": ["c"],
+          "server": ["s"],
+          "generate": ["g"],
+          "destroy": ["d"],
+          "dbconsole": []
+        },
+        "test_environment": {
+          "test_helper": {"test": ["rspec", "testrb"]}
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
zeus 会预先加载 rails 环境

相比 `spork` 具有以下特点：
1. 非侵入式，不需要修改项目文件，spork 在 Gemfile 中引入，且要修改 spec_helper.rb 或者 test_helper.rb
2. 运行各种 rails 命令都是秒开，spork 只能用于提高测试运行速度

安装

```
gem install zeus --no-ri --no-rdoc
```

运行

```
zeus start
```

如下图：

![gem-zeus-start](https://f.cloud.github.com/assets/15178/106306/8a1473aa-69f0-11e2-82f8-81949047eb4f.png)

之后运行 `zeus c` 启动控制台，`zeus rspec` 速度都非常快

参考资源
https://github.com/burke/zeus
http://robots.thoughtbot.com/post/40193452558/improving-rails-boot-time-with-zeus
#227
#236
