### PR TITLE
travis-ci 不要测试  jruby head, ruby1.9.2 环境

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
 
 rvm:
   - 1.9.3
-  - 1.9.2
+  #- 1.9.2
   #- ruby-head    # will cause timeout
 
 matrix:
@@ -30,21 +30,9 @@ matrix:
         - DATABASE=pg
         - TIMEOUT=1000
         - JRUBY_OPTS="-Xcext.enabled=true"
-    - rvm: jruby-head
-      jdk: openjdk7
-      env:
-        - DATABASE=pg
-        - TIMEOUT=1000
-        - JRUBY_OPTS="-Xcext.enabled=true"
   # jruby alwyas fails by unknown causes.
   allow_failures:
     - rvm: jruby-19mode
-      jdk: openjdk7
-      env:
-        - DATABASE=pg
-        - TIMEOUT=1000
-        - JRUBY_OPTS="-Xcext.enabled=true"
-    - rvm: jruby-head
       jdk: openjdk7
       env:
         - DATABASE=pg


### PR DESCRIPTION
最近几次 travis-ci 的测试总是报 [error](https://travis-ci.org/saberma/19wu/jobs/4447963/#L150)，都是跟 `jruby head` 环境有关，估计是受 travis-ci [JRuby: C extensions support is disabled](http://about.travis-ci.org/docs/user/languages/ruby/#JRuby%3A-C-extensions-support-is-disabled) 影响。
