### PR TITLE
#248 出错时自动给管理员发送异常信息邮件

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem 'mini_magick'
 group :production do
   # Use unicorn as the app server
   gem 'unicorn'
+  gem 'exception_notification'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,8 @@ GEM
     eventmachine (1.0.0)
     eventmachine (1.0.0-java)
     eventmachine (1.0.0-x86-mingw32)
+    exception_notification (3.0.1)
+      actionmailer (>= 3.0.4)
     execjs (1.4.0)
       multi_json (~> 1.0)
     factory_girl (4.1.0)
@@ -329,6 +331,7 @@ DEPENDENCIES
   coffee-rails (~> 3.2.1)
   delayed_job_active_record
   devise
+  exception_notification
   factory_girl_rails (~> 4.0)
   friendly_id
   gravtastic

--- a/config/initializers/middlewares.rb
+++ b/config/initializers/middlewares.rb
@@ -1,0 +1,6 @@
+if Rails.env.production?
+  NineteenWu::Application.config.middleware.use ExceptionNotifier,
+    :email_prefix => "[19wu] ",
+    :sender_address => Settings.email.from,
+    :exception_recipients => %W{#{Settings.email.from}}
+end

--- a/config/initializers/setup_mail.rb
+++ b/config/initializers/setup_mail.rb
@@ -1,12 +1,10 @@
 NineteenWu::Application.configure do
   config.action_mailer.delivery_method = Settings.email.delivery_method.to_sym
-  if Rails.env.development? || Rails.env.test?
-    config.action_mailer.delivery_method = Rails.env.test? ? :test : :file
-  end
 
   delivery_settings_key = "#{Settings.email.delivery_method}_settings"
   if delivery_settings = Settings.email[delivery_settings_key]
     config.action_mailer.send "#{delivery_settings_key}=", delivery_settings.symbolize_keys
+    ActionMailer::Base.send "#{delivery_settings_key}=", delivery_settings.symbolize_keys # fix for exception notification
   end
 
   config.action_mailer.default_url_options = {


### PR DESCRIPTION
加入 `exception notification` 后修正了个小问题，一并记录在这里。

原本 ActionMailer 是延迟加载的，直到加载像 [UserMailer](https://github.com/saberma/19wu/blob/master/app/mailers/user_mailer.rb#L1) 类才会加载 ActionMailer，同时将 `app.config.action_mailer` 的配置写入 ActionMailer.base 基类，具体顺序如下
1. 加载 [setup_mail.rb](https://github.com/saberma/19wu/blob/master/config/initializers/setup_mail.rb) ，配置会写入 app.config.action_mailer
2. 加载 [UserMailer](https://github.com/saberma/19wu/blob/master/app/mailers/user_mailer.rb#L1) 
3. 加载 ActionMailer，将 [app.config.action_mailer](http://git.io/RkBjVA) 写入  [ActionMailer::Base.smtp_settings](http://git.io/zefGgQ)
4. 调用 `deliver` 方法以 smtp 方式发送时会使用 `ActionMailer::Base.smtp_settings`，而不是 `app.config.action_mailer` 中的 `smtp_settings`

但 `exception_notification` 的 [Notifier](http://git.io/-hooyA) 类

```
class ExceptionNotifier
  class Notifier < ActionMailer::Base
  ...
  end  
end
```

会使 `action_mailer` 提前加载，`app.config.action_mailer` 的配置值无法再写入 `ActionMailer::Base.smtp_settings`，导致发送失败
#248
