### PR TITLE
去掉 therubyracer gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,8 @@
 # Some gems cannot/should not be installed on heroku and/or travis, but
 # `bundle --without` cannot be used. Put these gems into group :development
 # in such situations
-is_travis = !!ENV['TRAVIS']
 # should work until heroku changes the HOME directory location
 is_heroku = ['/app/','/app'].include?(ENV['HOME']) # ENV['HOME'] = '/app' in rails console or rake
-therubyracer_group = (is_travis || is_heroku) ? :development : :assets
 sqlite3_group = is_heroku ? :development : :sqlite3
 mysql2_group = is_heroku ? :development : :mysql2
 
@@ -82,20 +80,7 @@ group :assets do
   gem 'jquery-rails'
   gem 'bootstrap-datepicker-rails'
   gem 'jquery-fileupload-rails'
+  # 推荐安装 node.js，而不要 therubyracer
+  #gem 'libv8', '3.11.8.3', :platforms => :ruby # therubyracer 从 0.11 开始没有依赖 lib8. http://git.io/EtMkCg
+  #gem 'therubyracer', :platforms => :ruby
 end
-
-group therubyracer_group do
-  # Travis 编译coffee-script # 安装编译过程太慢(大概4分钟)
-  # Heroku 编译失败
-  gem 'libv8', '3.11.8.3', :platforms => :ruby # therubyracer 从 0.11 开始没有依赖 lib8. http://git.io/EtMkCg
-  gem 'therubyracer', :platforms => :ruby
-end
-
-# To use ActiveModel has_secure_password
-# gem 'bcrypt-ruby', '~> 3.0.0'
-
-# To use Jbuilder templates for JSON
-# gem 'jbuilder'
-
-# To use debugger
-# gem 'debugger'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,7 +157,6 @@ GEM
     json (1.7.7-java)
     kgio (2.8.0)
     kramdown (0.14.1)
-    libv8 (3.11.8.3)
     libwebsocket (0.1.7.1)
       addressable
       websocket
@@ -236,7 +235,6 @@ GEM
     rake (10.0.3)
     rdoc (3.12.2)
       json (~> 1.4)
-    ref (1.0.2)
     rinku (1.7.2)
     rspec (2.12.0)
       rspec-core (~> 2.12.0)
@@ -295,8 +293,6 @@ GEM
     sqlite3 (1.3.6-x86-mingw32)
     subexec (0.1.0)
     temple (0.5.5)
-    therubyracer (0.11.0)
-      ref
     thin (1.5.0)
       daemons (>= 1.0.9)
       eventmachine (>= 0.12.6)
@@ -352,7 +348,6 @@ DEPENDENCIES
   jquery-fileupload-rails
   jquery-rails
   kramdown
-  libv8 (= 3.11.8.3)
   mails_viewer
   mini_magick
   mysql2
@@ -369,7 +364,6 @@ DEPENDENCIES
   simplecov
   slim-rails
   sqlite3
-  therubyracer
   thin (~> 1.5.0)
   uglifier (>= 1.0.3)
   unicorn


### PR DESCRIPTION
`therubyracer` 在各个平台下的安装经常出问题，还是去掉好点，推荐安装 `node.js` 来代替
