### PR TITLE
在form中必须输入的项目的符号提示符变成红色

### DIFF
--- a/app/assets/stylesheets/modules/_event.css.scss
+++ b/app/assets/stylesheets/modules/_event.css.scss
@@ -73,3 +73,6 @@
     width: 140px;
   }
 }
+.event-form label.required abbr {
+    color: #CC0000;
+}


### PR DESCRIPTION
原来的那个`<abbr title="required">*</abbr>`虽然鼠标移动上去会给人个提示消息说这是个必填项，
但是感觉还是把这个符号给变成红色的话来得更好一些
