### PR TITLE
使用一个新的bootstrap-timepicker gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,7 +82,7 @@ group :assets do
   gem 'jquery-rails'
   gem 'bootstrap-datepicker-rails'
   gem 'jquery-fileupload-rails'
-  gem 'bootstrap-timepicker-rails', :require => 'bootstrap-timepicker-rails', :git => 'git://github.com/tispratik/bootstrap-timepicker-rails.git'
+  gem 'bootstrap-timepicker-rails-addon'
 
   # 推荐安装 node.js，而不要 therubyracer
   #gem 'libv8', '3.11.8.3', :platforms => :ruby # therubyracer 从 0.11 开始没有依赖 lib8. http://git.io/EtMkCg

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: git://github.com/tispratik/bootstrap-timepicker-rails.git
-  revision: ca57848827f8837148ebc05edcc44669dfb5fc71
-  specs:
-    bootstrap-timepicker-rails (0.1.2)
-      railties (>= 3.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -48,6 +41,8 @@ GEM
       railties (>= 3.0)
     bootstrap-sass (2.2.2.0)
       sass (~> 3.2)
+    bootstrap-timepicker-rails-addon (0.1.1.2)
+      railties (~> 3.1)
     builder (3.0.4)
     cancan (1.6.9)
     capistrano (2.14.2)
@@ -335,7 +330,7 @@ DEPENDENCIES
   activerecord-jdbcpostgresql-adapter
   bootstrap-datepicker-rails
   bootstrap-sass (~> 2.2.2.0)
-  bootstrap-timepicker-rails!
+  bootstrap-timepicker-rails-addon
   cancan
   capybara
   capybara-email

--- a/app/inputs/compound_datetime_input.rb
+++ b/app/inputs/compound_datetime_input.rb
@@ -25,7 +25,7 @@ class CompoundDatetimeInput < SimpleForm::Inputs::Base
   end
 
   def timepicker(builder)
-    template.content_tag(:div, :class => 'time input-append bootstrap-timepicker-component') do
+    template.content_tag(:div, :class => 'time input-append bootstrap-timepicker') do
       builder.text_field(:time, :class => 'timepicker') + timepicker_add_on
     end
   end


### PR DESCRIPTION
因为之前用的gem`bootstrap-timepicker-rails`与上游项目同步不及时，现在用一个新的gem来完成这个工作，以保证效果与最新的`bootstrap-timepicker`的效果相同
