### PR TITLE
Issue#355 根据活动地址显示百度地图

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -5,6 +5,7 @@
 #= require bootstrap-datepicker/core
 #= require jquery-fileupload/basic
 #= require jquery.textarea.caret
+#= require jquery.ba-throttle-debounce.min
 #= require bootstrap-timepicker
 #= require_self
 $ ->
@@ -133,18 +134,19 @@ $ ->
     map.addControl new BMap.ScaleControl()
     myGeo = new BMap.Geocoder()
 
-    updateMap = (location) ->
-      markers = map.getOverlays()
-      i = 0
-      while i < markers.length
-        map.removeOverlay markers[i]
-        i++
+    updateMap = $.debounce(200, (location) ->
+        console.log('hi')
+        markers = map.getOverlays()
+        i = 0
+        while i < markers.length
+          map.removeOverlay markers[i]
+          i++
 
-      myGeo.getPoint location, ((point) ->
-        if point
-          map.centerAndZoom point, 17
-          map.addOverlay new BMap.Marker(point)
-      ), "中国"
+        myGeo.getPoint location, ((point) ->
+          if point
+            map.centerAndZoom point, 17
+            map.addOverlay new BMap.Marker(point)
+        ), "中国")
 
     $("#event_location").keyup ->
       updateMap(@value)

--- a/app/assets/stylesheets/_2.layout.css.scss
+++ b/app/assets/stylesheets/_2.layout.css.scss
@@ -69,16 +69,3 @@
   height: 320px;
   width: 100%;
 }
-
-#l-map {
-  height: 100%;
-  width: 78%;
-  float: left;
-  border-right: 2px solid #bcbcbc;
-}
-
-#r-result {
-  height: 100%;
-  width: 100%;
-  float: left;
-}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -69,6 +69,6 @@ module ApplicationHelper
   end
 
   def baidu_map_enabled?
-    ! BaiduMap::ACCESS_KEY.nil?
+    ! Settings.baidumap_ak.empty?
   end
 end

--- a/app/views/events/_form.html.slim
+++ b/app/views/events/_form.html.slim
@@ -11,11 +11,10 @@
   = f.input :location_guide, :input_html => { :rows => 6, :class => 'span5' }, :as => 'uploadable'
   - if baidu_map_enabled?
     .control-group
-      label.string.required.control-label
-        | 地图预览
+      label.string.required.control-label = I18n.t('views.map_preview')
       .controls
         #mapPreview.span5
-    = javascript_include_tag "http://api.map.baidu.com/api?v=1.5&ak=" + BaiduMap::ACCESS_KEY
+    = javascript_include_tag "http://api.map.baidu.com/api?v=1.5&ak=" + Settings.baidumap_ak
   = f.input :content, :input_html => { :rows => 12, :class => 'span5' }, :as => 'uploadable'
 .form-actions
   = f.button :submit, :class => 'btn-info'

--- a/app/views/events/show.html.slim
+++ b/app/views/events/show.html.slim
@@ -31,7 +31,7 @@ article.event ng-init="event.id=#{@event.id}"
           .event-map == @event.location_guide_html
           - if baidu_map_enabled?
             #baiduMap data-location={@event.location}
-            = javascript_include_tag "http://api.map.baidu.com/api?v=1.5&ak=" + BaiduMap::ACCESS_KEY
+            = javascript_include_tag "http://api.map.baidu.com/api?v=1.5&ak=" + Settings.baidumap_ak
           hr
           p
             span.label.label-important 联系人

--- a/config/initializers/baidu_map.rb
+++ b/config/initializers/baidu_map.rb
@@ -1,4 +1,0 @@
-module BaiduMap
-  # Request your access key from http://lbsyun.baidu.com/apiconsole/key
-  ACCESS_KEY = nil
-end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -86,6 +86,7 @@ en:
   views:
     edit: "Edit"
     check_in: "Check in"
+    map_preview: "Map Preview"
     events:
       new:
         title: "Launch event"

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -88,6 +88,7 @@ zh-CN:
   views:
     edit: "修改"
     check_in: "签到"
+    map_preview: "地图预览"
     events:
       new:
         title: "发起活动"

--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -9,6 +9,11 @@ defaults: &defaults
   # host: '19wu.herokuapp.com'
   host: '19wu.com'
 
+  # Used to generate event location map automaticlly with Baidu Map API.
+  # You can request your access key from http://lbsyun.baidu.com/apiconsole/key
+  # By default, with an empty string, this feature will be disabled.
+  baidumap_ak: ''
+
   email: &email
     # Edit according to the smtp account domain.
     # e.g.

--- a/vendor/assets/javascripts/jquery.ba-throttle-debounce.min.js
+++ b/vendor/assets/javascripts/jquery.ba-throttle-debounce.min.js
@@ -1,0 +1,9 @@
+/*
+ * jQuery throttle / debounce - v1.1 - 3/7/2010
+ * http://benalman.com/projects/jquery-throttle-debounce-plugin/
+ * 
+ * Copyright (c) 2010 "Cowboy" Ben Alman
+ * Dual licensed under the MIT and GPL licenses.
+ * http://benalman.com/about/license/
+ */
+(function(b,c){var $=b.jQuery||b.Cowboy||(b.Cowboy={}),a;$.throttle=a=function(e,f,j,i){var h,d=0;if(typeof f!=="boolean"){i=j;j=f;f=c}function g(){var o=this,m=+new Date()-d,n=arguments;function l(){d=+new Date();j.apply(o,n)}function k(){h=c}if(i&&!h){l()}h&&clearTimeout(h);if(i===c&&m>e){l()}else{if(f!==true){h=setTimeout(i?k:l,i===c?e-m:e)}}}if($.guid){g.guid=j.guid=j.guid||$.guid++}return g};$.debounce=function(d,e,f){return f===c?a(d,e,false):a(d,f,e!==false)}})(this);


### PR DESCRIPTION
在config/settings.yml中增加一个新的配置项

``` yml
  # Used to generate event location map automaticlly with Baidu Map API.
  # You can request your access key from http://lbsyun.baidu.com/apiconsole/key
  # By default, with an empty string, this feature will be disabled.
  baidumap_ak: ''
```

默认baidumap_ak为nil则不启用百度地图。页面显示与以前一样。当将baidumap_ak设置为从百度申请的access key时，自动启用百度地图显示。效果如下：

活动编辑页面
![snip20130524_2](https://f.cloud.github.com/assets/1198651/559589/b0319802-c453-11e2-96ce-fa2c20db0df9.png)

活动展示页面边栏
![snip20130524_3](https://f.cloud.github.com/assets/1198651/559591/b6f26144-c453-11e2-874e-9db3b7f30811.png)

同时对keyup event 做了 debounce 处理
