### PR TITLE
活动变更内容字数限制为100字

### DIFF
--- a/app/controllers/event_summaries_controller.rb
+++ b/app/controllers/event_summaries_controller.rb
@@ -1,15 +1,14 @@
 class EventSummariesController < ApplicationController
   before_filter :authenticate_user!
+  before_filter :authorize_event!
   set_tab :event_summary, only: :new
 
   def new
-    @event = current_user.events.find(params[:event_id])
     @summary = @event.event_summary || @event.build_event_summary
     render :new
   end
 
   def create
-    @event = current_user.events.find(params[:event_id])
     @summary = @event.build_event_summary(params[:event_summary])
 
     if @summary.save
@@ -20,7 +19,6 @@ class EventSummariesController < ApplicationController
   end
 
   def update
-    @event = current_user.events.find(params[:event_id])
     @summary = @event.event_summary
 
     if @summary.update_attributes(params[:event_summary])

--- a/app/models/event_change.rb
+++ b/app/models/event_change.rb
@@ -1,7 +1,7 @@
 class EventChange < ActiveRecord::Base
   attr_accessible :content
   belongs_to :event
-  validates :content, length: { maximum: 50 }
+  validates :content, length: { maximum: 100 }
 
   after_create do
     event.participated_users.each do |user|

--- a/app/views/event_changes/new.html.slim
+++ b/app/views/event_changes/new.html.slim
@@ -4,16 +4,18 @@
   .span9
     = simple_form_for @change, html: {name: 'form', novalidate: ''} do |f|
       = f.label :content
-      textarea.span5 rows="7" cols="40" name="event_change[content]" placeholder=t('simple_form.placeholders.event_change.content') ng-init="content='#{@change.content}'" ng-maxlength="50" ng-model="content"
+      p.muted 可以输入活动时间、地点等变更信息
+      textarea.span5 rows="7" cols="40" name="event_change[content]" ng-init="content='（#{@event.title}）'" ng-maxlength="100" ng-model="content"
       p.muted
         |变更内容将以邮件、短信方式发送，剩余字数：
-        span.label.label-important {{50 - content.length}}
+        span.label.label-important {{100 - content.length}}
+        |，50字/条短信；
       p.muted
         |报名用户共有 
         span.label = @event.participated_users.size
         |&nbsp;人，将通过邮件通知他们，其中 
         span.label = @event.participated_users.with_phone.size
         |&nbsp;人登记了手机号码，将收到短信通知。
-      p.alert.alert-error ng-show="form.$invalid" 变更内容 不能超过 50 个字
+      p.alert.alert-error ng-show="form.$invalid" 变更内容 不能超过 100 个字
       .form-actions
         = f.button :submit, class: 'btn-info', 'ng-disabled' => "form.$invalid"

--- a/config/locales/simple_form.zh-CN.yml
+++ b/config/locales/simple_form.zh-CN.yml
@@ -31,8 +31,6 @@ zh-CN:
     placeholders:
       user:
         invite_reason: "活动组织情况(最近组织的几场活动?计划组织的下一场活动?)"
-      event_change:
-        content: "可以输入活动的时间、地点等变更信息"
     navtabs:
         write: "编写"
         preview: "预览"


### PR DESCRIPTION
变更内容默认以 `（{{活动标题}}）` 开头，总数不超过 `100字` ，超过 `50字` 时会分成两条短信发送，智能手机会自动 合并成1条

如下图：

![event-change-sms-limit](https://f.cloud.github.com/assets/15178/758124/d81dfd00-e713-11e2-8538-3b0f4a904783.png)

cc @windy 

close #396 
