### PR TITLE
[Rails4] Fix obsoleted rspec stub syntax.

### DIFF
--- a/spec/helpers/event_helper_spec.rb
+++ b/spec/helpers/event_helper_spec.rb
@@ -84,7 +84,7 @@ describe EventHelper do
   end
 
   describe '#event_follow_info' do
-    before { helper.stub :current_user, nil }
+    before { helper.stub current_user: nil }
     let(:event) { create :event }
     subject { helper.event_follow_info(event) }
     it { should eql [0, { false: '关注' , true: '已关注' }, false].to_json }


### PR DESCRIPTION
The following syntax is invalid now:

```
x.stub method, return_value
```

It should be change to

```
x.stub method => return_value
```

or

```
x.stub(method).and_return(return_value)
```
