### PR TITLE
[Rails4] Force Event#has? to return boolean

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -39,8 +39,11 @@ class Event < ActiveRecord::Base
     where(:start_time => tomorrow.beginning_of_day..tomorrow.end_of_day)
   }
 
+  # Must return boolean, because angularjs depends on the value to update UI.
+  # @see EventsController#join
+  # @see EventsController#quit
   def has?(user)
-    return user && participants.exists?(user_id: user.id)
+    return !!(user && participants.exists?(user_id: user.id))
   end
 
   def sibling_events

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -197,4 +197,21 @@ describe Event do
       expect(event.checkin_code).to eq '328'
     end
   end
+
+  describe '#has?' do
+    let(:user) { create(:user) }
+    before { event.save }
+
+    context 'when user has joined' do
+      before { event.participated_users << user }
+      it 'returns true' do
+        expect(event.has?(user)).to be(true)
+      end
+    end
+    context 'when user has not joined yet' do
+      it 'returns false' do
+        expect(event.has?(user)).to be(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Because translations `t('views.join.state'), t('views.join.title')` use
`true` and `false` as the key.

Refs #427
