### PR TITLE
Catch only ActiveRecord::RecordNotFound in middleware FallbackUrlRedirector

### DIFF
--- a/app/controllers/group_controller.rb
+++ b/app/controllers/group_controller.rb
@@ -1,12 +1,12 @@
 class GroupController < ApplicationController
   def event
-    group = Group.find_by_slug(params[:slug])
+    group = Group.where(slug: params[:slug]).first!
     @event = group.events.latest.first
     render 'events/show'
   end
 
   def followers
-    group = Group.find_by_slug(params[:slug])
+    group = Group.where(slug: params[:slug]).first!
     @event = group.events.latest.first
     render 'events/followers'
   end

--- a/app/middlewares/fallback_url_redirector.rb
+++ b/app/middlewares/fallback_url_redirector.rb
@@ -7,7 +7,7 @@ class FallbackUrlRedirector
     status, headers, body =
       begin
         @app.call(env)
-      rescue => e
+      rescue ActiveRecord::RecordNotFound
         if path = find_path(env)
           return [301, { 'Location' => path }, ["Redirecting you to #{path}"]]
         end


### PR DESCRIPTION
出现异常的时候会吃掉 backtrace
