### PR TITLE
change something in Gemfile let it worked in windows

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,10 +21,6 @@ if RUBY_VERSION =~ /1.9/
   Encoding.default_internal = Encoding::UTF_8
 end
 
-def windows_only
-  RbConfig::CONFIG['host_os'] =~ /mingw|mswin/i
-end
-
 gem 'rails', '4.0.0'
 gem 'slim-rails', '1.1.1'
 gem 'simple_form', '~> 3.0.0.rc'
@@ -53,12 +49,7 @@ group sqlite3_group do
 end
 
 group mysql2_group do
-  # newest version hasn't installed in windows
-  if windows_only
-    gem 'mysql2', '0.3.11'
-  else
-    gem 'mysql2'
-  end
+  gem 'mysql2', '0.3.11'
 end
 
 gem 'devise', '3.0.0.rc'
@@ -69,13 +60,7 @@ gem 'delayed_job_active_record', '~> 4.0.0.beta3'
 gem 'daemons'
 gem 'carrierwave'
 gem 'friendly_id', github: 'FriendlyId/friendly_id', branch: 'rails4'
-# newest version hasn't installed in windows.
-# but in #146, it has fixed it in master branch. see http://git.io/PlPFbw
-if windows_only
-  gem 'mini_magick', '3.5.0'
-else
-  gem 'mini_magick'
-end
+gem 'mini_magick', '3.5.0'
 gem 'rails-timeago'
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,7 @@ GEM
     arel (4.0.0)
     atomic (1.1.10)
     bcrypt-ruby (3.1.1)
+    bcrypt-ruby (3.1.1-x86-mingw32)
     bootstrap-datepicker-rails (1.1.1.1)
       railties (>= 3.0)
     bootstrap-sass (2.2.2.0)
@@ -126,6 +127,7 @@ GEM
     erubis (2.7.0)
     escape_utils (0.2.4)
     eventmachine (1.0.3)
+    eventmachine (1.0.3-x86-mingw32)
     exception_notification (4.0.0)
       actionmailer (>= 3.0.4)
       activesupport (>= 3.0.4)
@@ -137,6 +139,7 @@ GEM
       factory_girl (~> 4.2.0)
       railties (>= 3.0.0)
     ffi (1.9.0)
+    ffi (1.9.0-x86-mingw32)
     formatador (0.2.4)
     gemoji (1.4.0)
     github-markdown (0.5.3)
@@ -169,6 +172,7 @@ GEM
       rinku (~> 1.7)
       sanitize (~> 2.0)
     http_parser.rb (0.5.3)
+    http_parser.rb (0.5.3-x86-mingw32)
     i18n (0.6.4)
     jasmine-core (1.3.1)
     jquery-datatables-rails (1.11.2)
@@ -195,12 +199,13 @@ GEM
       rails (>= 3.1.0)
     method_source (0.8.1)
     mime-types (1.23)
-    mini_magick (3.6.0)
+    mini_magick (3.5.0)
       subexec (~> 0.2.1)
     mini_portile (0.5.1)
     minitest (4.7.5)
     multi_json (1.7.7)
-    mysql2 (0.3.12)
+    mysql2 (0.3.11)
+    mysql2 (0.3.11-x86-mingw32)
     net-scp (1.1.2)
       net-ssh (>= 2.6.5)
     net-sftp (2.1.2)
@@ -210,13 +215,21 @@ GEM
       net-ssh (>= 2.6.5)
     nokogiri (1.6.0)
       mini_portile (~> 0.5.0)
+    nokogiri (1.6.0-x86-mingw32)
+      mini_portile (~> 0.5.0)
     orm_adapter (0.4.0)
     pg (0.15.1)
+    pg (0.15.1-x86-mingw32)
     polyglot (0.3.3)
     pry (0.9.12.2)
       coderay (~> 1.0.5)
       method_source (~> 0.8)
       slop (~> 3.4)
+    pry (0.9.12.2-x86-mingw32)
+      coderay (~> 1.0.5)
+      method_source (~> 0.8)
+      slop (~> 3.4)
+      win32console (~> 1.3)
     pry-nav (0.2.3)
       pry (~> 0.9.10)
     pry-rails (0.3.1)
@@ -309,6 +322,7 @@ GEM
       activesupport (>= 3.0)
       sprockets (~> 2.8)
     sqlite3 (1.3.7)
+    sqlite3 (1.3.7-x86-mingw32)
     subexec (0.2.3)
     tabs_on_rails (2.2.0)
     temple (0.6.5)
@@ -337,11 +351,13 @@ GEM
     whenever (0.8.3)
       activesupport (>= 2.3.4)
       chronic (>= 0.6.3)
+    win32console (1.3.2-x86-mingw32)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
+  x86-mingw32
 
 DEPENDENCIES
   activerecord-jdbcpostgresql-adapter
@@ -379,8 +395,8 @@ DEPENDENCIES
   jquery-rails
   kramdown
   mails_viewer
-  mini_magick
-  mysql2
+  mini_magick (= 3.5.0)
+  mysql2 (= 0.3.11)
   pg
   pry-nav
   pry-rails


### PR DESCRIPTION
解决在 win 下升级到 rails4 时候出现的一些问题
1）`bundle install`时无法从 github 上安装 gem （出现encoding的错误）
2）`mysql2`只有 0.3.11 版本方便在 win 下安装，不然需要指定mysql的安装路径之类的
3）`mini_magick` 3.6.0 版本无法在 win 下安装，虽然 github 的 master 分支上已经更新了代码但是还没打包重新发布新版本

PS：Gemfile 里面有些 jruby 用的 gem，是不是可以删掉了？

<!---
@huboard:{"order":446.0}
-->
