### PR TITLE
可以选择capybara使用的浏览器

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ coverage
 
 # jasmine-rails
 spec/tmp
+
+# selenium
+libpeerconnection.log

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,12 @@ require 'capybara/rails'
 #require 'rspec/autorun' # http://j.mp/WLeAs3
 require 'capybara/email/rspec'
 
+selenium_browser = (ENV['SELENIUM_BROWSER'] || 'firefox').to_sym
+Capybara.register_driver selenium_browser do |app|
+  Capybara::Selenium::Driver.new(app, :browser => selenium_browser)
+end
+Capybara.javascript_driver = selenium_browser
+
 class Capybara::Email::Driver
   def raw
     if email.mime_type == 'multipart/alternative' && email.html_part


### PR DESCRIPTION
可以使用`SELENIUM_BROWSER`来选择使用的浏览器，例如`export SELENIUM_BROWSER="chrome"` 默认为firefox
