### PR TITLE
修复了assets中的若干问题

### DIFF
--- a/app/assets/javascripts/upload.js.coffee
+++ b/app/assets/javascripts/upload.js.coffee
@@ -20,13 +20,10 @@ $(document).ready ->
         el.show()
         el.next(".uploading").hide()
 
-
   $("textarea.uploadable").on("focus", ->
     $(this).next("p").addClass "focused"
   ).on "blur", ->
     $(this).next("p").removeClass "focused"
-
-
 
   $(".uploadable-input").each ->
     $this = $(this)
@@ -68,4 +65,3 @@ $(document).ready ->
               previewSec.find('.preview-loading').hide()
               previewSec.find('.previews').append(data.result)
         })
-

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -45,4 +45,4 @@
 @import "modules/topic";
 
 @import "modules/participant";
-@import "modules/event-map"
+@import "modules/event-map";

--- a/app/assets/stylesheets/bootstrap-custom.css.scss
+++ b/app/assets/stylesheets/bootstrap-custom.css.scss
@@ -42,7 +42,7 @@
 
 // Components: Misc
 //@import "bootstrap/thumbnails";
-//@import "bootstrap/media";
+@import "bootstrap/media";
 @import "bootstrap/labels-badges";
 //@import "bootstrap/progress-bars";
 //@import "bootstrap/accordion";


### PR DESCRIPTION
多余空行，缺漏分号，以及

```
WARNING on line 18 of /Users/jasl/workspace/ruby/19wu/app/assets/stylesheets/modules/_topic.css.scss: ".topic-item-title" failed to @extend ".media-heading".
  The selector ".media-heading" was not found.
  This will be an error in future releases of Sass.
  Use "@extend .media-heading !optional" if the extend should be able to fail.
```
