### PR TITLE
修复了travis-ci上mysql和sqlite的测试 #455

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ env:
     - secure: "EcbipPYfZxMS62cfroLKM7MGaShkuUH6Me2jMB/l9OhlD2gRUzXR9bQZx+1I\nGQMtk1v6D8KH2shR+8h6iKJzbD09mh8fDNBOBlLX2dlbCE1ZYJ2rYRFiCbcd\nSbcdP/xN+kOKo1Fe/eVCuQRTVYqHmMpwSSQA3Cbxv8pR31TCjNU="
   matrix:
     - DATABASE=pg
-    #- DATABASE=mysql2
-    #- DATABASE=sqlite3
+    - DATABASE=mysql2
+    - DATABASE=sqlite3
 
 rvm:
   #- 1.9.3

--- a/lib/tasks/travis.rake
+++ b/lib/tasks/travis.rake
@@ -7,7 +7,7 @@ namespace :travis do
     db = ENV['DATABASE'] || 'pg'
     verbose_system("cp -f config/database.yml.example.#{db} config/database.yml")
     verbose_system("cp -f config/settings.yml.example config/settings.yml")
-    verbose_system("bundle exec rake db:drop db:create db:schema:load --trace 2>&1")
+    verbose_system("bundle exec rake db:drop db:create db:migrate --trace 2>&1")
   end
 
   # append 'jasmine:ci' to run js tests


### PR DESCRIPTION
`db:migrate` 会更新schema.rb，这样就不会出问题，之前使用`db:schema:load`有什么特殊考虑么？
关联pr #455 
