### PR TITLE
Update devise and devise_invitable.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,8 +58,8 @@ group mysql2_group do
   gem 'mysql2', '0.3.11'
 end
 
-gem 'devise', '3.0.0.rc'
-gem 'devise_invitable', github: 'scambra/devise_invitable', branch: 'rails4'
+gem 'devise', '~> 3.0.1'
+gem 'devise_invitable', github: 'scambra/devise_invitable'
 gem 'settingslogic'
 gem "delayed_job", "~> 4.0.0.beta2"
 gem 'delayed_job_active_record', '~> 4.0.0.beta3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,12 +19,11 @@ GIT
 
 GIT
   remote: git://github.com/scambra/devise_invitable.git
-  revision: 1c6a50bb29f8637b3bffb05c2ba32e927d105113
-  branch: rails4
+  revision: 9e5a9a7e0e5ad489206386865efdfca5b87de62b
   specs:
-    devise_invitable (1.2.0.rc1)
-      actionmailer (>= 4.0.0.rc1)
-      railties (>= 4.0.0.rc1)
+    devise_invitable (1.1.8)
+      actionmailer (>= 3.2.6, < 5)
+      devise (>= 3.0.0.rc)
 
 GIT
   remote: git://github.com/searls/jasmine-rails.git
@@ -64,7 +63,7 @@ GEM
       tzinfo (~> 0.3.37)
     angularjs-rails (1.0.7)
     arel (4.0.0)
-    atomic (1.1.10)
+    atomic (1.1.12)
     bcrypt-ruby (3.1.1)
     bcrypt-ruby (3.1.1-x86-mingw32)
     bootstrap-datepicker-rails (1.1.1.1)
@@ -121,11 +120,11 @@ GEM
     delayed_job_active_record (4.0.0.beta3)
       activerecord (>= 3.0, < 4.1)
       delayed_job (>= 3.0, < 4.1)
-    devise (3.0.0.rc)
+    devise (3.0.1)
       bcrypt-ruby (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 3.2.6, < 5)
-      warden (~> 1.2.1)
+      warden (~> 1.2.3)
     diff-lcs (1.2.4)
     em-websocket (0.5.0)
       eventmachine (>= 0.12.9)
@@ -214,7 +213,7 @@ GEM
       subexec (~> 0.2.1)
     mini_portile (0.5.1)
     minitest (4.7.5)
-    multi_json (1.7.7)
+    multi_json (1.7.8)
     mysql2 (0.3.11)
     mysql2 (0.3.11-x86-mingw32)
     net-scp (1.1.2)
@@ -346,7 +345,7 @@ GEM
       eventmachine (>= 0.12.6)
       rack (>= 1.0.0)
     thor (0.18.1)
-    thread_safe (0.1.0)
+    thread_safe (0.1.2)
       atomic
     tilt (1.4.1)
     treetop (1.4.14)
@@ -396,7 +395,7 @@ DEPENDENCIES
   database_cleaner
   delayed_job (~> 4.0.0.beta2)
   delayed_job_active_record (~> 4.0.0.beta3)
-  devise (= 3.0.0.rc)
+  devise (~> 3.0.1)
   devise_invitable!
   escape_utils (= 0.2.4)
   exception_notification


### PR DESCRIPTION
Devise 3.0.1 has released. And Devise Invitable has already merged rails4
branch to master.

@saberma README 里的 badge 貌似要你手动更新
