### PR TITLE
修正了logo右侧navbar的样式，并分离为独立文件，便于扩展

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -24,6 +24,7 @@
 
 /* modules */
 
+@import "modules/nav-bar";
 @import "modules/user-bar";
 @import "modules/user-profile";
 

--- a/app/assets/stylesheets/modules/_nav-bar.css.scss
+++ b/app/assets/stylesheets/modules/_nav-bar.css.scss
@@ -1,0 +1,7 @@
+.navbar .nav {
+  > li {
+    > a {
+      padding: 14px 15px 14px;
+    }
+  }
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,6 +36,10 @@ module ApplicationHelper
     end
   end
 
+  def render_nav_bar
+    render 'signed_in_nav_bar' if user_signed_in?
+  end
+
   # Allow page to place flashes in specified place.
   # If the page did, do not render again.
   def render_flashes

--- a/app/views/application/_signed_in_nav_bar.html.slim
+++ b/app/views/application/_signed_in_nav_bar.html.slim
@@ -1,0 +1,3 @@
+ul.nav
+  - if can? :invite, User
+    li = link_to t('labels.invitations'), invitations_path

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -18,9 +18,7 @@ html ng-app='19wu'
             a.brand href="/"
               img.logo-wordmark src=image_path('logo-wordmark.png')
               span.alpha alpha
-            - if can? :invite, User
-              ul.nav
-                li = link_to t('labels.invitations'), invitations_path
+            = render_nav_bar
 
             .nav-collapse.collapse
               = render_user_bar


### PR DESCRIPTION
关联issue #469
由于header的高度和bootstrap默认有差别，所以navbar没有垂直居中，对此做出了修正。
为了使得布局文件代码清晰，故仿照user-bar的方式把nav-bar的代码独立出来。
