### PR TITLE
Disable sqlite3 test in Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
   matrix:
     - DATABASE=pg
     - DATABASE=mysql2
-    - DATABASE=sqlite3
+    #- DATABASE=sqlite3
 
 rvm:
   #- 1.9.3


### PR DESCRIPTION
The test using sqlite3 is not stable recently. Disable it until we have enough
time to find out the cause.
