### PR TITLE
更新friendly-id的调用

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -23,14 +23,14 @@ class InvitationsController < Devise::InvitationsController
 
   def mail
     authorize! :invite, User
-    user = User.find(params[:id])
+    user = User.friendly.find(params[:id])
     user.invite! current_user
     redirect_to invitations_path
   end
 
   def upgrade_invite
     authorize! :invite, User
-    user = User.find(params[:id])
+    user = User.friendly.find(params[:id])
     user.skip_invitation = true
     user.invite! current_user
     user.accept_invitation!

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   def show
-    @user = User.find(params[:id])
+    @user = User.friendly.find(params[:id])
     @profile = @user.profile
   end
 


### PR DESCRIPTION
friendly-id 5.x修改了api
之前merge的PR #506 没有修改api，导致测试不通过
同时解决了 #505 
