### PR TITLE
修复使用sqlite3时database_cleaner错误的使用pg_adapter而异常

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,7 @@ end
 group :test do
   gem 'capybara'
   gem 'capybara-email'
-  gem 'database_cleaner'
+  gem 'database_cleaner', '1.0.1'
   gem 'selenium-webdriver'
   gem 'poltergeist'
   gem 'simplecov', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,7 +123,7 @@ GEM
       simplecov (>= 0.7)
       thor
     daemons (1.1.9)
-    database_cleaner (1.1.1)
+    database_cleaner (1.0.1)
     delayed_job (4.0.0)
       activesupport (>= 3.0, < 4.1)
     delayed_job_active_record (4.0.0)
@@ -401,7 +401,7 @@ DEPENDENCIES
   cohort_me
   coveralls
   daemons
-  database_cleaner
+  database_cleaner (= 1.0.1)
   delayed_job (~> 4.0.0.beta2)
   delayed_job_active_record (~> 4.0.0.beta3)
   devise (~> 3.0.1)


### PR DESCRIPTION
这是database_cleaner的bug，退回1.0.1先
