### PR TITLE
重命名Event和EventChange的关联为updates

### DIFF
--- a/app/controllers/event_changes_controller.rb
+++ b/app/controllers/event_changes_controller.rb
@@ -6,15 +6,15 @@ class EventChangesController < ApplicationController
   set_tab :changes   , :sidebar, only: [:index]
 
   def index
-    @changes = @event.changes
+    @changes = @event.updates
   end
 
   def new
-    @change = @event.changes.build
+    @change = @event.updates.build
   end
 
   def create
-    @change = @event.changes.build(event_change_params)
+    @change = @event.updates.build(event_change_params)
     if @change.save
       redirect_to event_changes_path(@event)
     else

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -5,7 +5,7 @@ class Event < ActiveRecord::Base
   belongs_to :group
   has_one :event_summary
   has_many :participants, :class_name => "EventParticipant"
-  has_many :changes,      :class_name => "EventChange"
+  has_many :updates,      :class_name => "EventChange"
   has_many :tickets,      :class_name => "EventTicket"
   has_many :orders,       :class_name => "EventOrder"
   has_many :participated_users, :source => :user, :through => :participants do


### PR DESCRIPTION
因为`has_many :changes`生成的changes方法会覆盖到模型的同名方法，所以重命名掉 避免冲突
