### PR TITLE
活动页面样式小调整

### DIFF
--- a/app/assets/stylesheets/modules/_jumbotron.css.scss
+++ b/app/assets/stylesheets/modules/_jumbotron.css.scss
@@ -46,13 +46,3 @@
     margin: $baseLineHeight * 4 $gridColumnWidth + $gridGutterWidth;
   }
 }
-
-.alpha-alert {
-  @extend .alert, .alert-block, .alert-info;
-  margin: (3 * $baseLineHeight) 0 (2 * $baseLineHeight);
-  padding: 1.5 * $baseLineHeight;
-  text-align: center;
-  a {
-    padding: 4px;
-  }
-}

--- a/app/assets/stylesheets/modules/_label.css.scss
+++ b/app/assets/stylesheets/modules/_label.css.scss
@@ -3,6 +3,6 @@
 }
 
 .alpha {
-  @extend .label, .label-important;
+  @extend .label;
   margin-left: 10px;
 }

--- a/app/views/devise/mailer/invitation_instructions.html.slim
+++ b/app/views/devise/mailer/invitation_instructions.html.slim
@@ -1,17 +1,12 @@
-p 非常感谢您申请注册19屋，以下为 alpha 版本的注册邀请链接
+p 非常感谢您申请注册19屋，以下为注册邀请链接
 
 p = link_to accept_invitation_url(@resource, :invitation_token => @resource.invitation_token), accept_invitation_url(@resource, :invitation_token => @resource.invitation_token), title: '接受邀请'
 
-p
-  | 19屋是一个活动平台，专注于为组织者提供便利的活动发布、推广、售票等免费服务。现在您可以在19屋进行发布活动，签到等操作。这个平台是由 Ruby 社区成员驱动的，所有源代码都开放，您可以通过访问
-  = link_to 'https://github.com/saberma/19wu', 'https://github.com/saberma/19wu'
-  | 了解更多信息。
+p 19屋是一个活动平台，专注于为组织者提供便利的活动发布、推广、售票等免费服务。现在您可以在19屋进行发布活动，签到等操作。
 
 p
-  |在您使用的过程中，您可以随时联系我们，告诉我们您的想法。如果您遇到问题，可以发邮件到
+  |如需帮助，请发邮件到
   = link_to 'mahb45@gmail.com', 'mailto:mahb45@gmail.com'
-
-p 我非常期待您的反馈，怎样做才能使得这个产品更好，更有用呢?
 
 p 19屋 saberma
 br

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -34,7 +34,6 @@ html ng-app='19wu'
         #content
           .container
             = content_for?(:content) ? yield(:content) : yield
-            .alpha-alert = raw t('layout.alpha_alert', :email => link_to('Email', 'mailto:mahb45@gmail.com'), :github => link_to('Github', 'https://github.com/saberma/19wu/issues'))
 
     footer#footer
       .container
@@ -44,9 +43,10 @@ html ng-app='19wu'
             = link_to image_tag('sponsors/tui3.png'), 'http://tui3.com', target: '_blank', title: t('layout.sponsors.sms'), data: {toggle: 'tooltip'}
           .span4
             ul.pull-right
-              li #{link_to('19WU.COM', root_url)} &copy; #{Date.current.year} #{t('layout.copyright')}
-              li = link_to t('layout.opensource'), "http://github.com/saberma/19wu"
+              li = link_to t('layout.feedback'),  "https://github.com/saberma/19wu/issues/new"
               li = link_to t('layout.contact_us'), "mailto:mahb45@gmail.com"
+              li = link_to t('layout.opensource'), "http://github.com/saberma/19wu"
+              -#li &copy; #{Date.current.year} #{t('layout.copyright')}
 
     = javascript_include_tag "application"
     = javascript_include_tag "locales/#{locale}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,7 +18,7 @@ en:
   layout:
     opensource: "Fork us"
     contact_us: "Contact us"
-    alpha_alert: "%{19wu}正在 Alpha 阶段，如果您有任何意见或建议，可以通过%{email}或者%{github}联系我们。"
+    feedback: "反馈问题"
     title: "19wu - Make events better"
     copyright: "All rights reserved."
 

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -19,9 +19,9 @@ zh-CN:
     sponsors:
       title: 感谢19屋的赞助商：
       sms: 本站免费短信由推立方赞助
-    opensource: 本站开放源代码 @GitHub
+    opensource: 源代码@GitHub
     contact_us: "联系我们"
-    alpha_alert: "您可以通过 %{email} 或者 %{github} 向我们反馈问题。"
+    feedback: "反馈问题"
     title: "19屋－让活动更好"
     copyright: "版权所有"
 


### PR DESCRIPTION
1. 去掉“您可以通过 Email 或者 Github 向我们反馈问题。”，改为显示在右下角的“反馈问题”
2. Logo 右边的 alpha 改为灰色，原来的红色太抢眼
