### PR TITLE
修正重复支付的问题

### DIFF
--- a/app/controllers/user_orders_controller.rb
+++ b/app/controllers/user_orders_controller.rb
@@ -37,7 +37,7 @@ class UserOrdersController < ApplicationController
     callback_params = params.except(*request.path_parameters.keys)
     if callback_params.any? && Alipay::Sign.verify?(callback_params) && params[:trade_status] == 'TRADE_SUCCESS'
       @order = current_user.orders.find params[:id]
-      @order.pay!(params[:trade_no])
+      @order.pay!(params[:trade_no]) if @order.pending?
     end
   end
 


### PR DESCRIPTION
支付宝更新系统支付状态有两种方式：
1. 页面 done 更新（不一定会触发，用户可能跳转到 done 页面之前就关闭浏览器）
2. 后台 notify 更新（一定会触发）

这样就会有可能两次调用 order.pay! 方法，导致 StateMachine::InvalidTransition 异常。

所以得在调用 pay! 方法之前确保订单当前处理 pending 状态。

另两个与支付相关的修正由于比较紧急，没有提交 PR，这里列出来

df55d6d7ad260fe38737855f856e94134495930c
d2de66452dacdfa830dc6d5353ff2fbfcd36f8b3
