### PR TITLE
修正收到两份重复邮件的问题 #553

### DIFF
--- a/app/mailers/order_mailer.rb
+++ b/app/mailers/order_mailer.rb
@@ -6,21 +6,21 @@ class OrderMailer < ActionMailer::Base
     @order = order
     @event = order.event
     @user = order.user
-    mail(to: @user.email_with_login, subject: I18n.t('email.order.user.created.subject')).deliver
+    mail(to: @user.email_with_login, subject: I18n.t('email.order.user.created.subject'))
   end
 
   def notify_organizer_created(order)
     @order = order
     @event = order.event
     @user = order.user
-    mail(to: @event.user.email_with_login, subject: I18n.t('email.order.organizer.created.subject', title: @event.title, number: @order.number, login: @user.login )).deliver
+    mail(to: @event.user.email_with_login, subject: I18n.t('email.order.organizer.created.subject', title: @event.title, number: @order.number, login: @user.login ))
   end
 
   def notify_user_paid(order)
     @order = order
     @event = order.event
     @user = order.user
-    mail(to: @user.email_with_login, subject: I18n.t('email.order.user.paid.subject', number: order.number)).deliver
+    mail(to: @user.email_with_login, subject: I18n.t('email.order.user.paid.subject', number: order.number))
   end
 
   def notify_user_checkin_code(participant)
@@ -28,13 +28,13 @@ class OrderMailer < ActionMailer::Base
     @order = participant.order
     @event = @order.event
     @user = @order.user
-    mail(to: @user.email_with_login, subject: I18n.t('email.order.user.checkin_code.subject', number: @order.number, code: participant.checkin_code)).deliver
+    mail(to: @user.email_with_login, subject: I18n.t('email.order.user.checkin_code.subject', number: @order.number, code: participant.checkin_code))
   end
 
   def notify_organizer_paid(order)
     @order = order
     @event = order.event
     @user = order.user
-    mail(to: @event.user.email_with_login, subject: I18n.t('email.order.organizer.paid.subject', title: @event.title, number: @order.number, login: @user.login )).deliver
+    mail(to: @event.user.email_with_login, subject: I18n.t('email.order.organizer.paid.subject', title: @event.title, number: @order.number, login: @user.login ))
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -3,23 +3,23 @@ class UserMailer < ActionMailer::Base
   default from: Settings.email[:from]
 
   def welcome_email(user)
-    mail(:to => user.email, :subject => I18n.t('email.welcome.subject')).deliver
+    mail(:to => user.email, :subject => I18n.t('email.welcome.subject'))
   end
 
   def invited_email(user)
     @user = user
-    mail(:to => user.email, :subject => I18n.t('email.invited.subject', :login => user.login)).deliver
+    mail(:to => user.email, :subject => I18n.t('email.invited.subject', :login => user.login))
   end
 
   def notify_email(user, event)
     @user = user
     @event = event
-    mail(:to => user.email, :subject => I18n.t('email.notify.subject', :title => event.title)).deliver
+    mail(:to => user.email, :subject => I18n.t('email.notify.subject', :title => event.title))
   end
 
   def reminder_email(user, event)
     @user = user
     @event = event
-    mail(:to => user.email, :subject => I18n.t('email.reminder.subject')).deliver
+    mail(:to => user.email, :subject => I18n.t('email.reminder.subject'))
   end
 end


### PR DESCRIPTION
原因：delayed_job 在延迟处理邮件时已经会调用 `deliver` 方法，因此 Mailer 类中的方法就不需要再调用的了，否则就会发出两份邮件。

http://git.io/mLwZaw

close #553 
