### PR TITLE
merge duplicated ordered events in events#ordered

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -9,7 +9,7 @@ class EventsController < ApplicationController
   end
 
   def ordered
-    @events = current_user.ordered_events.latest
+    @events = current_user.ordered_events.latest.uniq
   end
 
   def show

--- a/app/views/home/_menu.html.slim
+++ b/app/views/home/_menu.html.slim
@@ -9,4 +9,4 @@ ul.home-nav
   li class=active?(current, :ordered_events)
     = link_to ordered_events_path do
       = t('home.menu.ordered_events')
-      span.label.amount = current_user.ordered_events.size
+      span.label.amount = current_user.ordered_events.uniq.size


### PR DESCRIPTION
  如果对一个活动提交过多个订单，之前会在“参加的活动”页面显示多次。
  本次改动对参加的活动做去重处理。
