### PR TITLE
improve usable

### DIFF
--- a/app/assets/stylesheets/modules/_event-order.css.scss
+++ b/app/assets/stylesheets/modules/_event-order.css.scss
@@ -12,3 +12,7 @@
     }
   }
 }
+
+.tickets-list {
+  margin-bottom: 0;
+}

--- a/app/assets/stylesheets/modules/_list.css.scss
+++ b/app/assets/stylesheets/modules/_list.css.scss
@@ -11,7 +11,6 @@ ul, ol {
   }
 }
 
-
 .list {
   .item {
     margin-bottom: $baseLineHeight / 2;

--- a/app/controllers/event_orders_controller.rb
+++ b/app/controllers/event_orders_controller.rb
@@ -7,7 +7,7 @@ class EventOrdersController < ApplicationController
 
   set_tab :order, only: [:stats, :index]
 
-  %i(all pending paid canceled refund_pending refunded).each do |item|
+  %i(pending paid canceled refund_pending refunded).each do |item|
     set_tab item, :sidebar, only: [:stats, :index]
   end
 

--- a/app/views/event_orders/_submenu.html.slim
+++ b/app/views/event_orders/_submenu.html.slim
@@ -1,6 +1,5 @@
 .span3
   .submenu
     = tabs_tag namespace: :sidebar, builder: EventOrdersSubmenu do |tab|
-      = tab.all t('menus.submenu.orders.all'), event_orders_path(@event), current_path
-      - %i(pending paid canceled refund_pending refunded).each do |status|
+      - %i(paid pending canceled refund_pending refunded).each do |status|
         = tab.send status, t("menus.submenu.orders.#{status}"), filter_event_orders_path(@event, status), current_path

--- a/app/views/event_orders/index.html.slim
+++ b/app/views/event_orders/index.html.slim
@@ -19,13 +19,14 @@
           th = t('views.my_orders.items')
           th = t('views.my_orders.price')
           th = t('views.my_orders.trade_no')
-          th = t('views.my_orders.status')
+          th = t('views.my_orders.operation')
       tbody
         - @orders.each do |order|
           tr
-            td = link_to order.user.login, order.user, target: '_blank'
             td
-              ul = render partial: 'user_orders/order_item', collection: order.items, as: 'item'
+              = link_to order.user.login, order.user, target: '_blank'
+            td
+              ul.tickets-list = render partial: 'user_orders/order_item', collection: order.items, as: 'item'
             td = order.price
             td = order.number
-            td = order.status_name
+            td = mail_to order.user.email, '邮件'

--- a/app/views/events/_menu.html.slim
+++ b/app/views/events/_menu.html.slim
@@ -8,7 +8,7 @@
       = tabs_tag builder: EventMenu do |tab|
         = tab.edit t('views.edit'), edit_event_path(@event)
         = tab.ticket t('views.ticket'), event_tickets_path(@event)
-        = tab.order t('views.sell'), event_orders_path(@event)
+        = tab.order t('views.sell'), filter_event_orders_path(@event, status: :paid)
         = tab.export t('views.export.export_link'), event_export_index_path(@event)
         = tab.change t('views.change'), new_event_change_path(@event)
         = tab.check_in t('views.check_in'), checkin_event_participants_path(@event)

--- a/app/views/user_orders/index.html.slim
+++ b/app/views/user_orders/index.html.slim
@@ -21,7 +21,7 @@ table.table.table-striped.table-bordered
       tr
         td = link_to order.event.title, order.event, target: '_blank'
         td
-          ul = render partial: 'user_orders/order_item', collection: order.items, as: 'item'
+          ul.tickets-list = render partial: 'user_orders/order_item', collection: order.items, as: 'item'
         td = order.price
         td = order.number
         td = order.status_name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -159,6 +159,7 @@ en:
       items: '票种'
       price: '价格（￥）'
       status: '状态'
+      operation: '操作'
       trade_no: '订单编号'
       created_at: '下单时间'
       operations: '操作'

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -195,6 +195,7 @@ zh-CN:
       items: '票种'
       price: '价格（￥）'
       status: '状态'
+      operation: '操作'
       trade_no: '订单编号'
       created_at: '下单时间'
       checkin_code: '签到码'


### PR DESCRIPTION
销售情况的“全部”很让人confusing，所以索性去掉了，这样，就不需要显示状态，另外，能够与取消订单或者没支付的人沟通很有用
