### PR TITLE
修正迁徙后订单门票单价未初始化的问题

### DIFF
--- a/db/migrate/20130921140156_add_unit_price_to_event_order_item.rb
+++ b/db/migrate/20130921140156_add_unit_price_to_event_order_item.rb
@@ -2,7 +2,7 @@ class AddUnitPriceToEventOrderItem < ActiveRecord::Migration
   def change
     add_column :event_order_items, :unit_price_in_cents, :integer, default: 0, null: false
     EventOrderItem.all.each do |event_order_item|
-      event_order_item.update_attribute :unit_price_in_cents, (event_order_item.price_in_cents / event_order_item.quantity)
+      event_order_item.update_column :unit_price_in_cents, (event_order_item.price_in_cents / event_order_item.quantity)
     end
   end
 end


### PR DESCRIPTION
#583 部署后发现订单门票的单价没有正确初始化，如下图：

![image](https://f.cloud.github.com/assets/15178/1186805/9d42797a-2324-11e3-97aa-698627586b51.png)

奇怪的开发环境下使用 `update_attribute` 更新却正常，先留意，有空深入研究下。
