### PR TITLE
自动关闭三天内未支付的订单

### DIFF
--- a/app/controllers/event_orders_controller.rb
+++ b/app/controllers/event_orders_controller.rb
@@ -7,7 +7,7 @@ class EventOrdersController < ApplicationController
 
   set_tab :order, only: [:stats, :index]
 
-  [:pending, :paid, :canceled, :refund_pending, :refunded].each do |item|
+  [:pending, :paid, :canceled, :closed, :refund_pending, :refunded].each do |item|
     set_tab item, :sidebar, only: [:stats, :index]
   end
 

--- a/app/models/event_order_observer.rb
+++ b/app/models/event_order_observer.rb
@@ -11,6 +11,10 @@ class EventOrderObserver < ActiveRecord::Observer
     order.event.increment! :tickets_quantity, order.quantity if order.event.tickets_quantity
   end
 
+  def after_close(order, transition)
+    order.event.increment! :tickets_quantity, order.quantity if order.event.tickets_quantity
+  end
+
   def after_request_refund(order, transition)
     order.event.increment! :tickets_quantity, order.quantity if order.event.tickets_quantity
   end

--- a/app/views/event_orders/_submenu.html.slim
+++ b/app/views/event_orders/_submenu.html.slim
@@ -1,5 +1,5 @@
 .span3
   .submenu
     = tabs_tag namespace: :sidebar, builder: EventOrdersSubmenu do |tab|
-      - [:pending, :paid, :canceled, :refund_pending, :refunded].each do |status|
+      - [:pending, :paid, :canceled, :closed, :refund_pending, :refunded].each do |status|
         = tab.send status, t("menus.submenu.orders.#{status}"), filter_event_orders_path(@event, status), current_path

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -107,6 +107,7 @@ en:
         pending: '未支付'
         paid: '已支付'
         canceled: '已取消'
+        closed: '已关闭'
         refund_pending: '等待处理退款'
         refunded: '退款成功'
         all: '全部'

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -143,6 +143,7 @@ zh-CN:
         pending: '未支付'
         paid: '已支付'
         canceled: '已取消'
+        closed: '已关闭'
         refund_pending: '等待处理退款'
         refunded: '退款成功'
         all: '全部'

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -22,3 +22,7 @@
 every 1.day, :at => '4:30 am' do
   runner "Event.remind_participants"
 end
+
+every 1.day, :at => '3:00 am' do
+  runner "EventOrder.cleanup_expired"
+end

--- a/spec/models/event_order_spec.rb
+++ b/spec/models/event_order_spec.rb
@@ -161,4 +161,14 @@ describe EventOrder do
     before { order }
     its(:tickets_quantity) { should eql 398 }
   end
+
+  describe 'clean up expired orders' do
+    before do
+      order.update_attributes! created_at: 4.days.ago
+      EventOrder.cleanup_expired
+      order.reload
+    end
+    subject { order }
+    its(:closed?) { should be_true }
+  end
 end


### PR DESCRIPTION
关联issue #587 
按照设计，3天内不支付的订单应当自动关闭，但之前并未实现这个需求
