### PR TITLE
fix: change gem source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ mysql2_group = is_heroku ? :development : :mysql2
 if ENV['TRAVIS']
   source 'https://rubygems.org'
 else
-  source 'http://ruby.taobao.org'
+  source 'https://gems.ruby-china.org'
 end
 
 # if not encoding, `bundle install` command would be error. (Invalid byte sequence in GBK)


### PR DESCRIPTION
之前用的`http://ruby.taobao.org`已经不能用了，bundle时会显示`Bundler::HTTPError Could not fetch specs from http://ruby.taobao.org/`。
换成https可用，不过现在社区里基本上用的都是ruby-china的gem source，所以我在这里也使用了。