### PR TITLE
fix: overflow css

### DIFF
--- a/app/assets/stylesheets/mixins/_sticky-footer.css.scss
+++ b/app/assets/stylesheets/mixins/_sticky-footer.css.scss
@@ -9,7 +9,7 @@
     min-height: 100%;
   }
   #main {
-    overflow: auto;
+    overflow: visible;
     padding-bottom: 145px;
     padding-top: 64px;
   }


### PR DESCRIPTION
修复 #656 中的问题
`overflow: auto;`会根据不同浏览器来判断。这里设置成`visible`会显示超出的部分。